### PR TITLE
Kernel 4.4+ compatibility

### DIFF
--- a/douane.c
+++ b/douane.c
@@ -1107,16 +1107,28 @@ static unsigned int netfiler_packet_hook(unsigned int hooknum,
   }
 }
 
+static unsigned int netfiler_packet_hook4(void *priv,
+			struct sk_buff *skb,
+			const struct nf_hook_state *state)
+{
+	return netfiler_packet_hook(state->hook, skb, (state->in), (state->out), NULL);
+}
 
 /*
 **  Netfiler hook
 */
 static struct nf_hook_ops nfho_outgoing = {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+  .hook     = netfiler_packet_hook4,
+#else
   .hook     = netfiler_packet_hook,
+#endif
   .hooknum  = NF_IP_LOCAL_OUT,
   .pf       = NFPROTO_IPV4,
   .priority = NF_IP_PRI_LAST,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
   .owner    = THIS_MODULE
+#endif
 };
 
 


### PR DESCRIPTION
I've made KISS change to allow usage of newer netfilter kernel hook struct, compiled fine on Debian 8 Jessie x86_64 (kernel `4.4+71~bpo8+1` from jessie-backports)

uname: 
```
Linux smarek 4.4.0-0.bpo.1-amd64 #1 SMP Debian 4.4.6-1~bpo8+1 (2016-03-20) x86_64 GNU/Linux
```

Also I've verified it works properly, using it now for a few hours, and works as expected.