### PR TITLE
netfilter_hook_version

### DIFF
--- a/douane.c
+++ b/douane.c
@@ -904,7 +904,11 @@ static unsigned int netfiler_packet_hook(void *priv, struct sk_buff *skb, const 
   *   Creating a socket in the userspace create a file that is added
   *   in the list of process opened files (On Linux everything is a file).
   */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
+  if (skb->sk && skb->sk->sk_state != TCP_TIME_WAIT)
+#else
   if (skb->sk && skb->sk->sk_state != TCP_TIME_WAIT && skb->sk->sk_state != TCP_NEW_SYN_RECV)
+#endif
   {
     if (skb->sk->sk_socket)
     {

--- a/douane.c
+++ b/douane.c
@@ -904,7 +904,7 @@ static unsigned int netfiler_packet_hook(void *priv, struct sk_buff *skb, const 
   *   Creating a socket in the userspace create a file that is added
   *   in the list of process opened files (On Linux everything is a file).
   */
-  if (skb->sk)
+  if (skb->sk && skb->sk->sk_state != TCP_TIME_WAIT && skb->sk->sk_state != TCP_NEW_SYN_RECV)
   {
     if (skb->sk->sk_socket)
     {

--- a/douane.c
+++ b/douane.c
@@ -1068,6 +1068,8 @@ static unsigned int netfiler_packet_hook(void *priv, struct sk_buff *skb, const 
   strcpy(activity->process_path, process_owner_path);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
   strcpy(activity->devise_name, out->name);
+#elif
+  strcpy(activity->devise_name, state->out->name);
 #endif
   activity->protocol = ip_header->protocol;
   strcpy(activity->ip_source, ip_source);

--- a/douane.c
+++ b/douane.c
@@ -676,7 +676,7 @@ static bool task_has_open_file(const struct task_struct * task, const struct fil
 static char * task_exe_path(struct task_struct * task, char * buff)
 {
   struct task_struct *  locked_task = task;
-  char                  tmpbuf[PATH_LENGTH];
+  char                  tmpbuf[PATH_MAX+11];
   int                   deleted_position;
 
   if (task == NULL)
@@ -695,7 +695,7 @@ static char * task_exe_path(struct task_struct * task, char * buff)
         // Get process path using d_path()
         // d_path() suffix the path with " (deleted)" when the file is still accessed
         // and the deletion of the file has been requested.
-        strcpy(buff, d_path(&locked_task->mm->exe_file->f_path, tmpbuf, PATH_LENGTH));
+        strncpy(buff, d_path(&locked_task->mm->exe_file->f_path, tmpbuf, PATH_MAX+11), PATH_LENGTH);
 
         task_unlock(locked_task);
 

--- a/douane.c
+++ b/douane.c
@@ -1068,7 +1068,7 @@ static unsigned int netfiler_packet_hook(void *priv, struct sk_buff *skb, const 
   strcpy(activity->process_path, process_owner_path);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
   strcpy(activity->devise_name, out->name);
-#elif
+#else
   strcpy(activity->devise_name, state->out->name);
 #endif
   activity->protocol = ip_header->protocol;


### PR DESCRIPTION
This pull request integrates changes in the netfilter hook function in relation to the version of the kernel.
Tested successfully on Ubuntu 14.04 with Kernel 3.13.0-85, Ubuntu 15.10 with Kernel 4.2.0-35 and Ubuntu 16.04 with Kernel 4.4.0-22.
This fix correct freeze problem for all kernel version.