### PR TITLE
Fix for Ubuntu 16.04.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,11 @@ endif
 
 # make
 all:
-	$(MAKE) -C /lib/modules/$(KERNEL_VERSION)/build M=$(PWD) modules
+	$(MAKE) -C /lib/modules/$(KERNEL_VERSION)/build M=$(shell pwd) modules
 
 # make clean
 clean:
-	$(MAKE) -C /lib/modules/$(KERNEL_VERSION)/build M=$(PWD) clean
+	$(MAKE) -C /lib/modules/$(KERNEL_VERSION)/build M=$(shell pwd) clean
 
 # make install (While developing, without using DKMS)
 install:

--- a/douane.c
+++ b/douane.c
@@ -30,6 +30,7 @@ enum nf_ip_hook_priorities {
 #include <linux/netfilter.h>      // nf_register_hook(), nf_unregister_hook()
 #include <linux/netlink.h>        // NLMSG_SPACE(), nlmsg_put(), NETLINK_CB(), NLMSG_DATA(), NLM_F_REQUEST, netlink_unicast(), netlink_kernel_release(), nlmsg_hdr(), NETLINK_USERSOCK, netlink_kernel_create()
 #include <linux/sched.h>          // for_each_process(), task_lock(), task_unlock()
+#include <linux/sched/signal.h>          // for_each_process(), task_lock(), task_unlock()
 #include <linux/ip.h>             // ip_hdr()
 #include <linux/udp.h>            // udp_hdr()
 #include <linux/tcp.h>            // tcp_hdr()


### PR DESCRIPTION
Fix to compile douane-dkms under Ubuntu 16.04.2.
Not tested under other versions/distros.